### PR TITLE
Remove @objc reference

### DIFF
--- a/SwiftPackage.xcodeproj/project.pbxproj
+++ b/SwiftPackage.xcodeproj/project.pbxproj
@@ -931,7 +931,6 @@
 				PRODUCT_NAME = SwiftPackage;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -952,7 +951,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "BundleDomain.SwiftPackage-iOS";
 				PRODUCT_NAME = SwiftPackage;
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -970,7 +968,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SwiftPackageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -987,7 +984,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.SwiftPackageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;


### PR DESCRIPTION
- We can explicitly add `@objc` when needed instead